### PR TITLE
Add SaveMissingModuleFix as dev dependency

### DIFF
--- a/Extension/YetAnotherPartyOrganiser.csproj
+++ b/Extension/YetAnotherPartyOrganiser.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <StartProgram>$(GameFolder)\bin\Win64_Shipping_Client\Bannerlord.exe</StartProgram>
-        <StartArguments>/singleplayer _MODULES_%2aNative%2aSandBox%2aSandBoxCore%2aStoryMode%2aCustomBattle%2aDeveloperConsole%2aModLib%2a0UIExtenderLibModule%2aYetAnotherPartyOrganiser%2a_MODULES_</StartArguments>
+        <StartArguments>/singleplayer _MODULES_%2aNative%2aSandBox%2aSandBoxCore%2aStoryMode%2aCustomBattle%2aDeveloperConsole%2aModLib%2a0UIExtenderLibModule%2aAragas.SaveMissingModuleFix%2aYetAnotherPartyOrganiser%2a_MODULES_</StartArguments>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <PlatformTarget>x64</PlatformTarget>


### PR DESCRIPTION
This way missing custom save data does not disturb the debugging workflow when running Bannerlord from the IDE. This does not affect the run configuration regarding the game launcher.

Once merged it should be mentioned in the [Contributing](https://github.com/tbeswick96/BannerlordYetAnotherPartyOrganiser/wiki/Contributing) section on the wiki.