### PR TITLE
Uiextenderlib 2.0.0

### DIFF
--- a/Extension/PartyScreenExtension.cs
+++ b/Extension/PartyScreenExtension.cs
@@ -1,5 +1,4 @@
-﻿using UIExtenderLib;
-using UIExtenderLib.Prefab;
+﻿using UIExtenderLib.Interface;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedType.Global

--- a/Extension/SubModule.xml
+++ b/Extension/SubModule.xml
@@ -13,7 +13,6 @@
         <DependedModule Id="CustomBattle"/>
         <DependedModule Id="StoryMode" />
         <DependedModule Id="ModLib" />
-        <DependedModule Id="0UIExtenderLibModule" />
     </DependedModules>
     <SubModules>
         <SubModule>

--- a/Extension/YapoSubModule.cs
+++ b/Extension/YapoSubModule.cs
@@ -18,28 +18,32 @@ namespace YAPO
 {
     public class YapoSubModule : MBSubModuleBase
     {
+        private readonly UIExtender _uiExtender = new UIExtender("YAPO");
+        
         protected override void OnSubModuleLoad()
         {
-            base.OnSubModuleLoad();
-
             try
             {
                 FileDatabase.Initialise(Strings.MODULE_FOLDER_NAME);
                 YapoSettings settings = FileDatabase.Get<YapoSettings>(YapoSettings.InstanceId) ?? new YapoSettings();
                 SettingsDatabase.RegisterSettings(settings);
 
-                UIExtender.Register();
                 new Harmony("YAPO").PatchAll();
+                _uiExtender.Register();
             }
             catch (Exception exception)
             {
                 ModDebug.ShowError("Failed to load YetAnotherPartyOrganiser", "OnSubModuleLoad exception", exception);
             }
         }
+        
+        protected override void OnBeforeInitialModuleScreenSetAsRoot()
+        {
+            _uiExtender.Verify();
+        }
 
         protected override void OnGameStart(Game game, IGameStarter gameStarterObject)
         {
-            base.OnGameStart(game, gameStarterObject);
             if (!(game.GameType is Campaign)) return;
 
             try

--- a/Extension/YapoSubModule.cs
+++ b/Extension/YapoSubModule.cs
@@ -18,7 +18,7 @@ namespace YAPO
 {
     public class YapoSubModule : MBSubModuleBase
     {
-        private readonly UIExtender _uiExtender = new UIExtender("YAPO");
+        private readonly UIExtender _uiExtender = new UIExtender("YetAnotherPartyOrganiser");
         
         protected override void OnSubModuleLoad()
         {

--- a/Extension/YetAnotherPartyOrganiser.csproj
+++ b/Extension/YetAnotherPartyOrganiser.csproj
@@ -62,18 +62,19 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="0Harmony, Version=2.0.0.9, Culture=neutral, PublicKeyToken=null">
-          <HintPath>packages\Lib.Harmony.2.0.0.9\lib\net472\0Harmony.dll</HintPath>
+        <Reference Include="0Harmony, Version=2.0.0.10, Culture=neutral, PublicKeyToken=null">
+          <HintPath>packages\Lib.Harmony.2.0.0.10\lib\net472\0Harmony.dll</HintPath>
           <Private>True</Private>
+        </Reference>
+        <Reference Include="UIExtenderLib_2.0.0.1, Version=2.0.0.1, Culture=neutral, PublicKeyToken=null">
+            <HintPath>packages\UIExtenderLib.2.0.0.1\lib\net472\UIExtenderLib_2.0.0.1.dll</HintPath>
+            <Private>True</Private>
         </Reference>
         <Reference Include="System" />
         <Reference Include="System.Core" />
         <Reference Include="System.Data" />
         <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
         <Reference Include="System.Xml" />
-        <Reference Include="UIExtenderLib">
-            <HintPath>$(GameFolder)\Modules\0UIExtenderLibModule\bin\Win64_Shipping_Client\UIExtenderLib.dll</HintPath>
-        </Reference>
         <Reference Include="ModLib">
             <HintPath>$(GameFolder)\Modules\ModLib\bin\Win64_Shipping_Client\ModLib.dll</HintPath>
         </Reference>
@@ -347,8 +348,10 @@
         <PostBuildEvent>mkdir "$(TargetDir)bin\Win64_Shipping_Client\"
             move "$(TargetDir)$(ProjectName).*" "$(TargetDir)bin\Win64_Shipping_Client\"
             move "$(TargetDir)0Harmony.*" "$(TargetDir)bin\Win64_Shipping_Client\"
-            move "$(TargetDir)UIExtenderLib.*" "$(TargetDir)bin\Win64_Shipping_Client\"
             move "$(TargetDir)ModLib.*" "$(TargetDir)bin\Win64_Shipping_Client\"
+            move "$(TargetDir)UIExtenderLib_*.*" "$(TargetDir)bin\Win64_Shipping_Client\"
+            move "$(TargetDir)Newtonsoft.Json.*" "$(TargetDir)bin\Win64_Shipping_Client\"
+            move "$(TargetDir)System.Management.*" "$(TargetDir)bin\Win64_Shipping_Client\"
         </PostBuildEvent>
     </PropertyGroup>
 </Project>

--- a/Extension/YetAnotherPartyOrganiser.csproj
+++ b/Extension/YetAnotherPartyOrganiser.csproj
@@ -68,7 +68,6 @@
         </Reference>
         <Reference Include="UIExtenderLib_2.0.0.1, Version=2.0.0.1, Culture=neutral, PublicKeyToken=null">
             <HintPath>packages\UIExtenderLib.2.0.0.1\lib\net472\UIExtenderLib_2.0.0.1.dll</HintPath>
-            <Private>True</Private>
         </Reference>
         <Reference Include="System" />
         <Reference Include="System.Core" />
@@ -350,8 +349,6 @@
             move "$(TargetDir)0Harmony.*" "$(TargetDir)bin\Win64_Shipping_Client\"
             move "$(TargetDir)ModLib.*" "$(TargetDir)bin\Win64_Shipping_Client\"
             move "$(TargetDir)UIExtenderLib_*.*" "$(TargetDir)bin\Win64_Shipping_Client\"
-            move "$(TargetDir)Newtonsoft.Json.*" "$(TargetDir)bin\Win64_Shipping_Client\"
-            move "$(TargetDir)System.Management.*" "$(TargetDir)bin\Win64_Shipping_Client\"
         </PostBuildEvent>
     </PropertyGroup>
 </Project>

--- a/Extension/packages.config
+++ b/Extension/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="2.0.0.9" targetFramework="net472" />
+  <package id="Lib.Harmony" version="2.0.0.10" targetFramework="net472" />
+  <package id="UIExtenderLib" version="2.0.0.1" targetFramework="net472" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Options can be found via the main menu option:
 
 ## Contributing
 
-_This mod is open source, so please feel free to explore it.
+This mod is open source, so please feel free to explore it. It isn't perfect but we are working on it.
 
-It isn't perfect but we are working on it.
-
-If you want to help don't hesitate to get into contact and have a look at our [contribution guide](https://github.com/tbeswick96/BannerlordYetAnotherPartyOrganiser/wiki/Contributing)._
+If you want to help don't hesitate to get into contact and have a look at our [contribution guide](https://github.com/tbeswick96/BannerlordYetAnotherPartyOrganiser/wiki/Contributing).

--- a/README.md
+++ b/README.md
@@ -77,5 +77,7 @@ Options can be found via the main menu option:
 ## Contributing
 
 _This mod is open source, so please feel free to explore it.
+
 It isn't perfect but we are working on it.
+
 If you want to help don't hesitate to get into contact and have a look at our [contribution guide](https://github.com/tbeswick96/BannerlordYetAnotherPartyOrganiser/wiki/Contributing)._

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Known mods that use an outdated Harmony version (< 2.0.0.9)
 - Workshop Demystifier
 - Tournaments XPanded
 
-_This mod is open source, so please feel free to explore it.
-It isn't perfect but we are working on it.
-If you want to help don't hesitate to get into contact and have a look at our [contribution guide](https://github.com/tbeswick96/BannerlordYetAnotherPartyOrganiser/wiki/Contributing)._
-
 ## Dependencies
 
 | Dependency | Mandatory | Notes |
@@ -47,7 +43,7 @@ Make sure that the dependent mods are enabled and listed above this mod within t
 - Button to place upgradable troops at the top of the list
 - Buttons will disable themselves if functionality is not available (e.g. cannot set opposite sorting if no Then By mode is selected)
 - Sorting configuration is saved to your save file
- 
+
 ### Party Actions
 
 - Upgrade single-path upgradable troops
@@ -77,3 +73,9 @@ Options can be found via the main menu option:
 - Configurable upgrade rules
 - Handling of multi-path upgradable troops
 - Configurable main party prisoner and other party troops/prisoner (after battle) recruitment rules
+
+## Contributing
+
+_This mod is open source, so please feel free to explore it.
+It isn't perfect but we are working on it.
+If you want to help don't hesitate to get into contact and have a look at our [contribution guide](https://github.com/tbeswick96/BannerlordYetAnotherPartyOrganiser/wiki/Contributing)._

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@
 
 ### Another party organisation mod to add to your ever expanding collection!
 
-_**Disclaimer**:
-Yes, we know a lot of these mods have been released in the space of a few days.
-Many had similar ideas and implemented them in different ways.
-Over the course of the next few weeks it's likely some of these mods will either lose support from their dev(s), or be merged into one or few feature-complete mods that everyone uses.
-We encourage the latter, as long as the resulting mods are open sourced._
+**IMPORTANT** If you used a version prior to 1.2.0, UIExtenderLibModule is a deprecated mod. Make sure you remove this mod from your load order. The library is included with this mod.
+
+**IMPORTANT** If you have any mods that use a Harmony version < 2.0.0.9, make these are loaded AFTER any mod that uses a Harmony version >= 2.0.0.9.
+
+In other words, a mod using a Harmony version >= 2.0.0.9 needs to be loaded first. The safest way to do this is to load ModLib first after the official modules.
+
+Know mods that use an outdated Harmony version < 2.0.0.9
+
+- Bannerlord Tweaks
+- Workshop Demystifier
+- Tournaments XPanded
 
 _This mod is open source, so please feel free to explore it.
 It isn't perfect but we are working on it.
@@ -18,9 +24,8 @@ If you want to help don't hesitate to get into contact and have a look at our [c
 
 | Dependency | Mandatory | Notes |
 |------------|:---------:|-------|
-| [UIExtenderLib](https://www.nexusmods.com/mountandblade2bannerlord/mods/323) | ✓ | Used to safely extend the game UI |
 | [ModLib](https://www.nexusmods.com/mountandblade2bannerlord/mods/592) | ✓ | Used to provide settings and other goodies |
-| [Save Missing Module Fix](https://www.nexusmods.com/mountandblade2bannerlord/mods/282) | ✗ | Recommended as it ensures saves can be loaded when you unload this mod having saved a game with it enabled |
+| [Save Missing Module Fix](https://www.nexusmods.com/mountandblade2bannerlord/mods/282) | ✗ | Recommended as it ensures saves can be loaded when you unload this mod having saved a game with it enabled (Ensure this is loaded BEFORE Yet Another Party Organiser) |
 
 Make sure that the dependent mods are enabled and listed above this mod within to launcher.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,7 @@
 
 **IMPORTANT** If you used a version prior to 1.2.0, UIExtenderLibModule is a deprecated mod. Make sure you remove this mod from your load order. The library is included with this mod.
 
-**IMPORTANT** If you have any mods that use a Harmony version < 2.0.0.9, make sure these are loaded AFTER any mod that uses a Harmony version >= 2.0.0.9.
-
-In other words, a mod using a Harmony version >= 2.0.0.9 needs to be loaded first. The safest way to do this is to load ModLib first after the official modules.
-
-Known mods that use an outdated Harmony version (< 2.0.0.9)
-
-- Bannerlord Tweaks
-- Workshop Demystifier
-- Tournaments XPanded
+**IMPORTANT** To ensure compatibility between Harmony versions across different modules, it is advised to load ModLib as the first Module after the official modules. If this is not done, the game may error on startup as an older version of harmony might be loaded first
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 **IMPORTANT** If you used a version prior to 1.2.0, UIExtenderLibModule is a deprecated mod. Make sure you remove this mod from your load order. The library is included with this mod.
 
-**IMPORTANT** If you have any mods that use a Harmony version < 2.0.0.9, make these are loaded AFTER any mod that uses a Harmony version >= 2.0.0.9.
+**IMPORTANT** If you have any mods that use a Harmony version < 2.0.0.9, make sure these are loaded AFTER any mod that uses a Harmony version >= 2.0.0.9.
 
 In other words, a mod using a Harmony version >= 2.0.0.9 needs to be loaded first. The safest way to do this is to load ModLib first after the official modules.
 
-Know mods that use an outdated Harmony version < 2.0.0.9
+Known mods that use an outdated Harmony version (< 2.0.0.9)
 
 - Bannerlord Tweaks
 - Workshop Demystifier
@@ -25,7 +25,7 @@ If you want to help don't hesitate to get into contact and have a look at our [c
 | Dependency | Mandatory | Notes |
 |------------|:---------:|-------|
 | [ModLib](https://www.nexusmods.com/mountandblade2bannerlord/mods/592) | ✓ | Used to provide settings and other goodies |
-| [Save Missing Module Fix](https://www.nexusmods.com/mountandblade2bannerlord/mods/282) | ✗ | Recommended as it ensures saves can be loaded when you unload this mod having saved a game with it enabled (Ensure this is loaded BEFORE Yet Another Party Organiser) |
+| [Save Missing Module Fix](https://www.nexusmods.com/mountandblade2bannerlord/mods/282) | ✗ | Recommended as it ensures saves can be loaded when you unload this mod having saved a game with it enabled |
 
 Make sure that the dependent mods are enabled and listed above this mod within to launcher.
 


### PR DESCRIPTION
**When merged this pull request will:**

- Update UIExtenderLib to 2.0.0
- Add UIExtenderLib as a Nuget package
- Remove UIExtenderLibModule from SubModule dependencies
- Update classes to use new references
- Update PartyVmMixin `_vm` references to use field resolves from Mixin weak reference
- Update Harmony to 2.0.0.10
- Updated readme with details on UIExtenderLib requirement, and Harmony versions